### PR TITLE
Small installation and model fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install .
 
 2. To fit codacore on some data:
 ```python
-from codacore.models import CodaCore
+from codacore.model import CodaCore
 from codacore.datasets import simulate_hts
 x, y = simulate_hts(1000, 100)
 model = CodaCore(objective='binary_classification', type='balance')

--- a/codacore/model.py
+++ b/codacore/model.py
@@ -164,7 +164,7 @@ class CodaCore:
     def get_denominator_parts(self, base_learner_index):
         return list(np.where(self.ensemble[base_learner_index].denominator_parts)[0])
 
-    def get_logratios(self, x):
+    def get_logratio(self, x):
         """
         Takes a set of compositional inputs (of the same shape
         as the original training data) and produces the
@@ -175,7 +175,7 @@ class CodaCore:
         """
         logratios = np.zeros([x.shape[0], len(self.ensemble)])
         for j in range(len(self.ensemble)):
-            logratios[:, j] = self.ensemble[j].get_logratios(x)
+            logratios[:, j] = self.ensemble[j].get_logratio(x)
         return logratios
 
 class CodaCoreBase:

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/egr95/py-codacore",
-    python_requires='==3.5, ==3.6, ==3.7, ==3.8',
+    python_requires=">=3.5, <3.9",
     install_requires=[
         'tensorflow>=2.4.0',
         'scikit-learn',


### PR DESCRIPTION
Hi, and thanks for developing CoDaCoRe!

While I was installing it and running through the README's example, I noticed a few problems that caused problems for the installation on my computer. I am submitting fixes for these here:

- The `setup.py` change makes the Python version checks less exact -- what happened was I installed CoDaCoRe into a fresh conda environment with Python version 3.8.10, and trying to install the package failed because my Python version wasn't exactly 3.8 (I guess the `.10` throws things off). Since I don't think this is the desired behavior, the modified `setup.py` now uses a range of Python versions that allows for small version number variations.

- The README tries to import from `codacore.models`, which doesn't work; importing from `codacore.model` does work.
 
- The `model.get_logratios()` function failed when I called it with `x` (the variable from the README's example as of writing). The error message I got pointed to [this line in the code](https://github.com/egr95/py-codacore/blob/23e9e7265a2741b6d3e441fea6bd3aa2584eea04/codacore/model.py#L178) and said `AttributeError: 'CodaCoreBase' object has no attribute 'get_logratios'`. Changing the function called to `get_logratio` (without the `s`) fixes this; I've also changed the function name to just `model.get_logratio()`, but I'm not sure if having the name be plural or not is desired.

I should also note a fourth error that I do not submit a fix for here, since I'm unsure how it could best be fixed in a machine-independent way. When running `from codacore.model import CodaCore` for the first time, I got an error about the `hdf5` version not matching in `h5py`: the error message was mostly the same as the message shown [here](https://stackoverflow.com/questions/60367297/yet-another-h5py-is-running-against-hdf5-1-10-5-when-it-was-built-against-1-10), although the exact warning was `h5py is running against HDF5 1.10.7 when it was built against 1.10.6, this may cause problems`. I was able to fix this by just running `conda install hdf5=1.10.6`, but if it'd be possible to prevent this mismatch automatically that might be nice.

Thank you again!