### PR TITLE
Fix set_cv_params and set_opt_params

### DIFF
--- a/codacore/model.py
+++ b/codacore/model.py
@@ -60,10 +60,9 @@ class CodaCore:
             'num_thresholds': 20,
         }
 
-        if cv_params is None:
-            return default_params
-        else:
-            return default_params.update(cv_params)
+        if cv_params is not None:
+            default_params.update(cv_params)
+        return default_params
 
     def set_opt_params(self, opt_params):
         """Overrides the defaults with any user-specified params"""
@@ -76,10 +75,9 @@ class CodaCore:
             'epsilon_b': 1e-2,
         }
 
-        if opt_params is None:
-            return default_params
-        else:
-            return default_params.update(opt_params)
+        if opt_params is not None:
+            default_params.update(opt_params)
+        return default_params
 
     def fit(self, x, y):
         """

--- a/tests/test_codacore.py
+++ b/tests/test_codacore.py
@@ -2,7 +2,7 @@
 from codacore.model import CodaCore
 from codacore.datasets import simulate_hts
 
-def test_codacore():
+def test_codacore(cv_params=None, opt_params=None):
     """Test codacore"""
     seed = 0
     n = 1000
@@ -10,7 +10,8 @@ def test_codacore():
     x, y = simulate_hts(n, p, random_state=seed)
     x = x + 1
 
-    model = CodaCore(random_state=seed, objective='binary_classification')
+    model = CodaCore(random_state=seed, objective='binary_classification',
+                     cv_params=cv_params, opt_params=opt_params)
     model.fit(x, y)
 
     assert 0 in model.get_numerator_parts(0)
@@ -19,7 +20,8 @@ def test_codacore():
     x, y = simulate_hts(n, p, logratio='balance', random_state=seed)
     x = x + 1
 
-    model = CodaCore(random_state=seed, objective='binary_classification')
+    model = CodaCore(random_state=seed, objective='binary_classification',
+                     cv_params=cv_params, opt_params=opt_params)
     model.fit(x, y)
 
     assert 3 in model.get_numerator_parts(0)
@@ -29,7 +31,8 @@ def test_codacore():
     x, y = simulate_hts(n, p, logratio='amalgamation', random_state=seed)
     x = x + 1
 
-    model = CodaCore(random_state=seed, objective='binary_classification', type='SLR')
+    model = CodaCore(random_state=seed, objective='binary_classification', type='SLR',
+                     cv_params=cv_params, opt_params=opt_params)
     model.fit(x, y)
 
     assert 0 in model.get_numerator_parts(0)
@@ -38,3 +41,6 @@ def test_codacore():
 
 if __name__ == '__main__':
     test_codacore()
+    test_codacore(cv_params={'num_folds': 4})
+    test_codacore(opt_params={'epochs': 20})
+    test_codacore(cv_params={'num_folds': 4}, opt_params={'epochs': 111})


### PR DESCRIPTION
set_cv_params and set_opt_params would fail if default values were
changed. The update method for dictionaries works "in place" so the
return value of calling update is always None. I reused the test
function in test_codacore.py to ensure this works as expected.