### PR TITLE
Fix: Make the codebase runnable and resolve runtime errors

### DIFF
--- a/codacore/model.py
+++ b/codacore/model.py
@@ -157,10 +157,10 @@ class CodaCore:
         return
 
     def get_numerator_parts(self, base_learner_index):
-        return list(np.where(self.ensemble[base_learner_index].numerator_parts)[0])
+        return [int(i) for i in np.where(self.ensemble[base_learner_index].numerator_parts)[0]]
 
     def get_denominator_parts(self, base_learner_index):
-        return list(np.where(self.ensemble[base_learner_index].denominator_parts)[0])
+        return [int(i) for i in np.where(self.ensemble[base_learner_index].denominator_parts)[0]]
 
     def get_logratios(self, x):
         """
@@ -270,8 +270,8 @@ class CodaCoreBase:
             return model
 
         # First train for 1 epoch with lr = 1 to find adaptive lr
-        model = gradient_descent(1, 1)
-        lr = self.opt_params['adaptive_lr'] / np.max(np.abs(model.relaxation_layer.get_weights()[0]))
+        model = gradient_descent(1.0, 1)
+        lr = float(self.opt_params['adaptive_lr'] / np.max(np.abs(model.relaxation_layer.get_weights()[0])))
         # Now we can use our adaptive lr to retrain
         model = gradient_descent(lr, self.opt_params['epochs'])
 

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,6 @@
 import setuptools
 import sys
 
-if sys.version_info < (3, 5):
-    raise EnvironmentError('Sorry, Python < 3.5 is not supported')
-if sys.version_info > (3, 9):
-    raise EnvironmentError('Sorry, Python >= 3.9 is not supported')
-
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
@@ -19,7 +14,6 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/egr95/py-codacore",
-    python_requires=">=3.5, <3.9",
     install_requires=[
         'tensorflow>=2.4.0',
         'scikit-learn',


### PR DESCRIPTION
This commit addresses several issues that prevented the code from running on newer Python versions and caused runtime errors.

- Removed the strict Python version constraint in `setup.py` to allow installation on Python 3.9+.
- Fixed `TypeError` in `codacore/model.py` by explicitly casting numpy float and integer types to standard Python `float` and `int` types before passing them to Keras/Tensorflow functions. This resolves issues with newer versions of Tensorflow that are more strict about input types.
- Cleaned up the output of the `summary()` method to display clean integers for numerator and denominator parts.